### PR TITLE
Fix issue with search params

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,14 @@ d3.csv("scrapes/ban140.csv", function(data) {
 	for (var i = 0; i < data.length; i++) {
 		Everything.push(data[i]);
 	}
+
+	// populate data from search params once CSV data loaded
+	let params = new URLSearchParams(window.location.search);
+	if (params.get("mode") && params.get("points")) {
+		updateValuesInternal(params.get("mode"), params.get("points"));
+		pointsModeElement.value = params.get("mode");
+		pendingPointsElement.value = params.get("points");
+	}
 });
 
 let infoTableArray = [
@@ -266,12 +274,6 @@ let foldDurationElement = document.getElementById("foldduration");
 
 $(document).ready(function(){
 	$('[data-toggle="popover"]').popover(); 
-	let params = new URLSearchParams(window.location.search);
-	if (params.get("mode") && params.get("points")) {
-		updateValuesInternal(params.get("mode"), params.get("points"));
-		pointsModeElement.value = params.get("mode");
-		pendingPointsElement.value = params.get("points");
-	}
 });
 
 function updateValues() {


### PR DESCRIPTION
I heard that the search params to specify points and points mode (`pp` or `ppd`) had stopped working, so I checked what was going on. The issue appears to be that the initial `updateValuesInternal` call was running before the folding data CSV file had finished loading. I moved that `updateValuesInternal` call into the `d3.csv` callback.

If you have any concerns, please let me know. Thanks for making this awesome tool!